### PR TITLE
Remove defunct navigation

### DIFF
--- a/wp-content/themes/aboutex/header.php
+++ b/wp-content/themes/aboutex/header.php
@@ -32,7 +32,7 @@
 
 </head>
 <body <?php if (is_page('index')) echo 'id="home"'; ?>>
-  
+
   <script src="https://assets.extension.org/javascripts/global_nav_internal.js" type="text/javascript"></script>
 
 <div id="frame">
@@ -40,28 +40,24 @@
 <div id="header">
   <h1><a href="<?php echo get_option('home'); ?>/"><?php bloginfo('name'); ?></a></h1>
   <ul id="user_actions">
-    <li><a href="<?php bloginfo('url'); ?>/get-an-id" title="Get an ID">Register</a></li>
     <li class="last"><a href="<?php bloginfo('url'); ?>/get-started" title="Get an ID">Getting Started</a></li>
   </ul>
-  
-  <div id="search">    
+
+  <div id="search">
     <?php include (TEMPLATEPATH . '/searchform.php'); ?>
   </div>
-  
+
   <ul id="nav">
     <li><a <?php echo is_page('about') ? 'class="current"' : ""; ?> href="<?php bloginfo('url'); ?>/about" title="About Us">About Us</a></li>
     <li><a <?php if (is_home()) echo('class="current" '); ?> href="<?php bloginfo('url'); ?>/blog" title="Blog" >Blog</a></li>
-    <li><a <?php echo is_page('tools') ? 'class="current"' : ""; ?> href="<?php bloginfo('url'); ?>/tools" title="Tools">eX Tools</a></li>
     <li><a href="http://www.extension.org/" title="extension.org">extension.org</a></li>
-    <li><a <?php echo is_page('foundation') ? 'class="current"' : ""; ?> href="<?php bloginfo('url'); ?>/foundation" title="eXtension Foundation">eXtension Foundation</a></li>
-    <li id="support" class="last"><a <?php echo is_page('foundation') ? 'class="current"' : ""; ?> href="<?php bloginfo('url'); ?>/foundation/donate/" title="Support eXtension">Support eXtension</a></li>
+    <li id="support" class="last"><a href="<?php bloginfo('url'); ?>/about/donate/" title="Support eXtension">Support eXtension</a></li>
   </ul>
 </div>
 
 <div id="mini_banner">
   <div id="mini_art"></div>
   <ul id="call_to_action">
-    <li><a href="<?php bloginfo('url'); ?>/get-an-id" title="Get an ID" class="button gray primary cat small">Get your eXtension ID</a></li>
-    <li><a href="<?php bloginfo('url'); ?>/get-started" title="Get Started" class="button gray secondary cat small">Getting Started with eXtension</a></li>
+    <li><a href="<?php bloginfo('url'); ?>/get-started" title="Get Started" class="button gray primary cat small">Getting Started with eXtension</a></li>
   </ul>
 </div>

--- a/wp-content/themes/aboutex/header.php
+++ b/wp-content/themes/aboutex/header.php
@@ -51,7 +51,6 @@
     <li><a <?php echo is_page('about') ? 'class="current"' : ""; ?> href="<?php bloginfo('url'); ?>/about" title="About Us">About Us</a></li>
     <li><a <?php if (is_home()) echo('class="current" '); ?> href="<?php bloginfo('url'); ?>/blog" title="Blog" >Blog</a></li>
     <li><a href="http://www.extension.org/" title="extension.org">extension.org</a></li>
-    <li id="support" class="last"><a href="<?php bloginfo('url'); ?>/about/donate/" title="Support eXtension">Support eXtension</a></li>
   </ul>
 </div>
 

--- a/wp-content/themes/aboutex/sitehome.php
+++ b/wp-content/themes/aboutex/sitehome.php
@@ -15,31 +15,30 @@ Template Name: Sitehome
 <div id="primary">
   <div id="aboutex">
     <h2>What is eXtension?</h2>
-    <p>eXtension is an Internet-based collaborative environment where Land Grant University content providers exchange objective, research-based knowledge to solve real challenges in real time.</p> 
+    <p>eXtension is an Internet-based collaborative environment where Land Grant University content providers exchange objective, research-based knowledge to solve real challenges in real time.</p>
     <p><a class="more" href="<?php bloginfo('url'); ?>/about/">Learn More...</a></p>
   </div>
-    
+
   <ul id="call_to_action">
-    <li><a href="<?php bloginfo('url'); ?>/get-an-id" title="Get an ID" class="button white primary cat">Get your eXtension ID</a></li>
-    <li><a href="<?php bloginfo('url'); ?>/get-started" title="Get Started" class="button white secondary cat">Getting Started with eXtension</a></li>
+    <li><a href="<?php bloginfo('url'); ?>/get-started" title="Get Started" class="button white primary cat">Getting Started with eXtension</a></li>
   </ul>
 </div>
 </div>
 
-        
+
 <div id="bottombox">
     <div id="featured_news">
         <h3>Featured News</h3>
         <?php wp_nav_menu(array('menu_id' => 'homepage_links')); ?>
     </div>
-    
+
   <div id="latest_posts">
     <h3>Latest Blog Posts</h3>
     <ul id="posts">
     <?php get_archives('postbypost', '14', 'custom', '<li>', '</li>'); ?>
     </ul>
   </div>
-  
+
   <div id="col3">
     <div id="quicklinks">
       <h3>Quick Links</h3>
@@ -50,4 +49,3 @@ Template Name: Sitehome
 </div>
 
 <?php get_footer(); ?>
-

--- a/wp-content/themes/aboutex/subnav-about.php
+++ b/wp-content/themes/aboutex/subnav-about.php
@@ -2,13 +2,7 @@
     <h3>About Us</h3>
     <ul>
       <li><a href="<?php bloginfo('url'); ?>/about/">Overview</a></li>
-        <li><a href="<?php bloginfo('url'); ?>/about/mission/">Mission</a></li>
-        <li><a href="<?php bloginfo('url'); ?>/about/staff/">Staff</a></li>
-        <li><a href="<?php bloginfo('url'); ?>/about/history/">History</a></li>
-        <li><a href="<?php bloginfo('url'); ?>/about/policies/">Policies</a></li>
-        <li><a href="<?php bloginfo('url'); ?>/about/organization/">Organization</a></li>
-        <li><a href="<?php bloginfo('url'); ?>/foundation/partnership/">Partnerships</a></li>
-        <li class="external"><a href="<?php bloginfo('url'); ?>/graphicstandards/">Graphic Standards Guidelines</a></li>
-        <li><a href="<?php bloginfo('url'); ?>/foundation/">eXtension Foundation</a></li>
+      <li><a href="<?php bloginfo('url'); ?>/about/staff/">Staff</a></li>
+      <li class="external"><a href="<?php bloginfo('url'); ?>/graphicstandards/">Graphic Standards Guidelines</a></li>  
     </ul>
 </div>


### PR DESCRIPTION
- This changes removes the "Tools", "eXtension Foundation" and "Support eXtension" links for the primary navigation.
- It also removes the 'Register" and "Get your eXtension ID" calls to action which are being consolidated under the "Getting Started" action.